### PR TITLE
Fix uniprot URL link

### DIFF
--- a/lib/dat/dat.go
+++ b/lib/dat/dat.go
@@ -177,7 +177,7 @@ func (d *Base) Fetch(id, temp string, iso, rev bool) {
 	d.UniProtDB = fmt.Sprintf("%s%s%s.fas", temp, string(filepath.Separator), id)
 
 	if rev {
-		query = fmt.Sprintf("%s%s%s", "http://www.uniprot.org/uniprot/?query=reviewed:yes+AND+proteome:", id, "&format=fasta")
+		query = fmt.Sprintf("%s%s%s", "http://www.uniprot.org/uniprot/?query=reviewed:true+AND+proteome:", id, "&format=fasta")
 	} else {
 		query = fmt.Sprintf("%s%s%s", "http://www.uniprot.org/uniprot/?query=proteome:", id, "&format=fasta")
 	}


### PR DESCRIPTION
query was not downloading any sequences before (for UP000005640). By changing  "yes" to "true" and it seems to be working for me. 

Note I am not familiar with the go language however I don't think this should break anything.

Also not sure if the previous statement does not work anymore or if I am just trying to fetch the database on an unlucky day. 