### PR TITLE
Allow external tuning of Go runtime

### DIFF
--- a/lib/id/pep.go
+++ b/lib/id/pep.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -356,7 +357,7 @@ func ReadPepXMLInput(xmlFile, decoyTag, temp string, models bool) (PepIDListPtrs
 		}
 	}
 	wg := sync.WaitGroup{}
-	parallelism := 6
+	parallelism := runtime.GOMAXPROCS(0)
 	parallelismTokens := make(chan struct{}, parallelism)
 	wg.Add(len(sortedFiles))
 	for idx, i := range sortedFiles {

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"runtime/debug"
-
 	"github.com/Nesvilab/philosopher/cmd"
 )
 
@@ -19,7 +17,6 @@ var (
 )
 
 func main() {
-	debug.SetGCPercent(20)
 	cmd.Version = version
 	cmd.Build = build
 


### PR DESCRIPTION
Allow use of environment variables `GOGC`, `GOMAXPROCS`, `GOMEMLIMIT` for tuning of runtime.