### PR TITLE
fix bug introduced in 0f80898 for xtag masses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION = $(shell date +%Y%m%d)
 BUILD = $(shell  date +%Y%m%d%H%M)
 
 TAG = v5.0.0
-RC = RC24
+RC = RC25
 
 LDFLAGS = -ldflags "-w -s -extldflags -static -X main.version=${TAG} -X main.build=${BUILD}"
 

--- a/lib/qua/iso.go
+++ b/lib/qua/iso.go
@@ -159,7 +159,7 @@ func prepareLabelStructureWithMS2(dir, format, brand, plex string, tol float64, 
 					}
 				}
 
-				if brand != "sclip" && i.Mz.DecodedStream[j] > 137 {
+				if brand != "sclip" && brand != "xtag" && i.Mz.DecodedStream[j] > 137 {
 					break
 				} else if i.Mz.DecodedStream[j] > 450 {
 					break
@@ -312,7 +312,7 @@ func prepareLabelStructureWithMS3(dir, format, brand, plex string, tol float64, 
 					}
 				}
 
-				if brand != "sclip" && i.Mz.DecodedStream[j] > 137 {
+				if brand != "sclip" && brand != "xtag" && i.Mz.DecodedStream[j] > 137 {
 					break
 				} else if i.Mz.DecodedStream[j] > 450 {
 					break


### PR DESCRIPTION
both "xtag" and "sclip" brands need the extended m/z range