### PR TITLE
Fix: Adjust I and L after razor assignment #

### DIFF
--- a/lib/rep/updater.go
+++ b/lib/rep/updater.go
@@ -1,6 +1,7 @@
 package rep
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -454,8 +455,9 @@ func (evi *Evidence) UpdateLayerswithDatabase(dbBin, decoyTag string) {
 	}
 
 	type peptideData struct {
-		Start int // Peptide start position in the protein
-		End   int // Peptide end position in the protein
+		Start    int    // Peptide start position in the protein
+		End      int    // Peptide end position in the protein
+		Sequence string // Peptide sequence as observed in the protein
 	}
 	var updatedPeptideData = make(map[string]peptideData)
 
@@ -501,13 +503,21 @@ func (evi *Evidence) UpdateLayerswithDatabase(dbBin, decoyTag string) {
 			adjustEnd = -1
 		}
 
-		// Map the peptide to the protein, update ProteinStart and ProteinEnd positions
+		// Map the peptide to the protein, update ProteinStart and ProteinEnd positions, replace the
+		// peptide and modifiedPeptide sequences with the observed sequence from the protein record
+		// to fix a potential I/L mixup issue.
 		mstart := strings.Index(replacerIL.Replace(rec.Sequence), extendedPeptide)
 		mend := mstart + len(extendedPeptide)
+		sequenceAsObservedInProtein := rec.Sequence[mstart+adjustStart-1 : mend+adjustEnd]
+		newModifiedPeptide, updateModifiedPeptideErr := updateModifiedSequence(evi.PSM[i].Peptide, evi.PSM[i].ModifiedPeptide, sequenceAsObservedInProtein)
 
 		evi.PSM[i].ProteinStart = mstart + adjustStart
 		evi.PSM[i].ProteinEnd = mend + adjustEnd
-		updatedPeptideData[evi.PSM[i].Peptide] = peptideData{evi.PSM[i].ProteinStart, evi.PSM[i].ProteinEnd}
+		evi.PSM[i].Peptide = sequenceAsObservedInProtein
+		if updateModifiedPeptideErr == nil {
+			evi.PSM[i].ModifiedPeptide = newModifiedPeptide
+		}
+		updatedPeptideData[evi.PSM[i].Peptide] = peptideData{evi.PSM[i].ProteinStart, evi.PSM[i].ProteinEnd, sequenceAsObservedInProtein}
 
 		// map the flanking aminoacids
 		flanks := regexp.MustCompile(`(\w{0,7})` + regexp.QuoteMeta(extendedPeptide) + `(\w{0,7})`)
@@ -573,9 +583,14 @@ func (evi *Evidence) UpdateLayerswithDatabase(dbBin, decoyTag string) {
 			tmp.MappedGenes[geneName] = struct{}{}
 		}
 
-		// update start and positions with correct values derived from the protein database
+		// update start and positions, sequence and modified sequence with correct values derived from the protein database
 		peptideData := updatedPeptideData[evi.Ions[i].Sequence]
 		tmp.ProteinStart, tmp.ProteinEnd = peptideData.Start, peptideData.End
+		newModifiedSequence, updateModifiedSequenceErr := updateModifiedSequence(tmp.Sequence, tmp.ModifiedSequence, peptideData.Sequence)
+		tmp.Sequence = peptideData.Sequence
+		if updateModifiedSequenceErr == nil {
+			tmp.ModifiedSequence = newModifiedSequence
+		}
 	}
 
 	for i := range evi.Peptides {
@@ -599,6 +614,7 @@ func (evi *Evidence) UpdateLayerswithDatabase(dbBin, decoyTag string) {
 		if peptideData, ok := updatedPeptideData[evi.Peptides[i].Sequence]; ok {
 			evi.Peptides[i].ProteinStart = peptideData.Start
 			evi.Peptides[i].ProteinEnd = peptideData.End
+			evi.Peptides[i].Sequence = peptideData.Sequence
 		}
 
 		// update mapped genes
@@ -929,4 +945,47 @@ func (evi *Evidence) ApplyRazorAssignment(decoyTag string) {
 			evi.Peptides[i].IsDecoy = true
 		}
 	}
+}
+
+// Replaces the amino acid sequence of a modified sequence with the updated sequence
+// Used to fix I and L amino acids being mixed up in modified sequences after using PromoteProteinIDs()
+// Returns an empty string when the modifiedOriginalSequence is an empty string
+func updateModifiedSequence(originalSequence string, modifiedOriginalSequence string, updatedSequence string) (string, error) {
+	// test that the original sequence has the same length as updated sequence, otherwise return an error
+	if len(originalSequence) != len(updatedSequence) {
+		return "", errors.New("originalSequence and updatedSequence must have the same length")
+	}
+
+	// Find positions of modification tags, i.e. all pairs of "[" and "]" along with their modification strings
+	var modPositions []int
+	var modificationTags []string
+	for i := 0; i < len(modifiedOriginalSequence); i++ {
+		if modifiedOriginalSequence[i] == '[' {
+			start := i
+			for j := i; j < len(modifiedOriginalSequence); j++ {
+				if modifiedOriginalSequence[j] == ']' {
+					modPositions = append(modPositions, start)
+					modificationTags = append(modificationTags, modifiedOriginalSequence[start:j+1])
+					i = j
+					break
+				}
+			}
+		}
+	}
+
+	// Remove all pairs of "[" and "]" along with their modification string
+	modifiedSequenceWithoutModTags := modifiedOriginalSequence
+	for _, content := range modificationTags {
+		modifiedSequenceWithoutModTags = strings.Replace(modifiedSequenceWithoutModTags, content, "", 1)
+	}
+
+	// Replace originalSequence with updatedSequence
+	observedModifiedSequence := strings.Replace(modifiedSequenceWithoutModTags, originalSequence, updatedSequence, 1)
+
+	// Add the modification tags back at the right modPositions
+	for i, pos := range modPositions {
+		observedModifiedSequence = observedModifiedSequence[:pos] + modificationTags[i] + observedModifiedSequence[pos:]
+	}
+
+	return observedModifiedSequence, nil
 }

--- a/lib/rep/updater.go
+++ b/lib/rep/updater.go
@@ -453,8 +453,11 @@ func (evi *Evidence) UpdateLayerswithDatabase(dbBin, decoyTag string) {
 		}
 	}
 
-	var proteinStart = make(map[string]int)
-	var proteinEnd = make(map[string]int)
+	type peptideData struct {
+		Start int // Peptide start position in the protein
+		End   int // Peptide end position in the protein
+	}
+	var updatedPeptideData = make(map[string]peptideData)
 
 	replacerIL := strings.NewReplacer("L", "I")
 	for i := range evi.PSM {
@@ -477,54 +480,37 @@ func (evi *Evidence) UpdateLayerswithDatabase(dbBin, decoyTag string) {
 			}
 		}
 
+		// The flanking amino acids are added to the peptide, in order to map it properly to the protein
+		// by also considering the enzymatic cleavage rules. The extended peptide is then used to find
+		// its start and end indices in the protein (mstart, mend). Finally, for reporting the real
+		// peptide start and end positions the indices need to be adjusted, taking into account the
+		// flanking amino acids that were added to the peptide, as well as the zero-based indexing.
 		var adjustStart = 0
 		var adjustEnd = 0
 
-		peptide := replacerIL.Replace(evi.PSM[i].Peptide)
-
+		extendedPeptide := replacerIL.Replace(evi.PSM[i].Peptide)
 		if evi.PSM[i].PrevAA != "-" && len(evi.PSM[i].PrevAA) == 1 {
-			peptide = replacerIL.Replace(evi.PSM[i].PrevAA) + peptide
+			extendedPeptide = replacerIL.Replace(evi.PSM[i].PrevAA) + extendedPeptide
 			adjustStart = +2
 		}
-
 		if evi.PSM[i].PrevAA == "-" && len(evi.PSM[i].PrevAA) == 1 {
 			adjustStart = +1
 		}
-
 		if evi.PSM[i].NextAA != "-" && len(evi.PSM[i].NextAA) == 1 {
-			peptide = peptide + replacerIL.Replace(evi.PSM[i].NextAA)
+			extendedPeptide = extendedPeptide + replacerIL.Replace(evi.PSM[i].NextAA)
 			adjustEnd = -1
 		}
 
-		// map the peptide to the protein
-		mstart := strings.Index(replacerIL.Replace(rec.Sequence), peptide)
-		mend := mstart + len(peptide)
+		// Map the peptide to the protein, update ProteinStart and ProteinEnd positions
+		mstart := strings.Index(replacerIL.Replace(rec.Sequence), extendedPeptide)
+		mend := mstart + len(extendedPeptide)
 
 		evi.PSM[i].ProteinStart = mstart + adjustStart
 		evi.PSM[i].ProteinEnd = mend + adjustEnd
-
-		proteinStart[evi.PSM[i].Peptide] = evi.PSM[i].ProteinStart
-		proteinEnd[evi.PSM[i].Peptide] = evi.PSM[i].ProteinEnd
-
-		// {
-		// 	proteinStart[evi.PSM[i].Peptide] = mstart
-		// 	proteinEnd[evi.PSM[i].Peptide] = mend
-
-		// 	seq := recordMap[evi.PSM[i].Protein].Sequence
-
-		// 	fmt.Println(evi.PSM[i].Peptide)
-		// 	fmt.Println(peptide)
-
-		// 	fmt.Println(mstart)
-
-		// 	mapPep := seq[mstart:mend]
-		// 	fmt.Println(mapPep)
-
-		// 	fmt.Println("")
-		// }
+		updatedPeptideData[evi.PSM[i].Peptide] = peptideData{evi.PSM[i].ProteinStart, evi.PSM[i].ProteinEnd}
 
 		// map the flanking aminoacids
-		flanks := regexp.MustCompile(`(\w{0,7})` + regexp.QuoteMeta(peptide) + `(\w{0,7})`)
+		flanks := regexp.MustCompile(`(\w{0,7})` + regexp.QuoteMeta(extendedPeptide) + `(\w{0,7})`)
 		f := flanks.FindAllStringSubmatch(replacerIL.Replace(rec.Sequence), -1)
 
 		var left string
@@ -577,8 +563,6 @@ func (evi *Evidence) UpdateLayerswithDatabase(dbBin, decoyTag string) {
 			evi.Ions[i].IsDecoy = true
 		}
 
-		tmp.ProteinStart, tmp.ProteinEnd = proteinStart[tmp.Sequence], proteinEnd[tmp.Sequence]
-
 		// update mapped genes
 		for k := range ion.MappedProteins {
 			if strings.Contains(k, decoyTag) {
@@ -588,6 +572,10 @@ func (evi *Evidence) UpdateLayerswithDatabase(dbBin, decoyTag string) {
 			geneName := recordMap[k].GeneNames
 			tmp.MappedGenes[geneName] = struct{}{}
 		}
+
+		// update start and positions with correct values derived from the protein database
+		peptideData := updatedPeptideData[evi.Ions[i].Sequence]
+		tmp.ProteinStart, tmp.ProteinEnd = peptideData.Start, peptideData.End
 	}
 
 	for i := range evi.Peptides {
@@ -608,11 +596,9 @@ func (evi *Evidence) UpdateLayerswithDatabase(dbBin, decoyTag string) {
 			evi.Peptides[i].IsDecoy = true
 		}
 
-		if seq, ok := proteinStart[evi.Peptides[i].Sequence]; ok {
-			evi.Peptides[i].ProteinStart = seq
-		}
-		if seq, ok := proteinEnd[evi.Peptides[i].Sequence]; ok {
-			evi.Peptides[i].ProteinEnd = seq
+		if peptideData, ok := updatedPeptideData[evi.Peptides[i].Sequence]; ok {
+			evi.Peptides[i].ProteinStart = peptideData.Start
+			evi.Peptides[i].ProteinEnd = peptideData.End
 		}
 
 		// update mapped genes


### PR DESCRIPTION
Propesed fix for issue #430 and issue #500 

To test the modifications I've made in philosopher I used the released (5.1.1) and the newly compiled philosopher and run FragPipe on a hela sample.

- First, I tested if the refactoring I made had any effects. I've compared the `psm`, `combined_ion`, `combined_peptide`, and `combined_protein` tables between the original and the refactored version and they were all identical.
- Next, I tested the version with the I/L fix. First, I looked at the `psm`, `combined_ion`, and `combined_peptide` tables, replaced all "I" with "L" in the sequences, sorted by the new sequence and compared the tables between the original and fixed version, they were identical.
- Finally, I checked if the I/L mixup was fixed in the `psm`, `combined_ion`, and `combined_peptide` tables. I used the "Start position" and "End position" columns together with the reported protein and extracted the expected peptide sequence from the FASTA file. Then I compared the expected with the reported sequences. For the current version (5.1.1) of Philosopher there were mismatches, whereas in the fixed version the I/L mixup was gone.

From what I could tell, it looks fine.

**Limitation**: For updating the sequence of modified peptide entries, I am assuming that modifications are always indicated by square brackets `[modification]` (and there are no additional square brackets within the modification, `[mod[i]fication]`). I couldn't find the definition of the pepXML schema, but at least in the FragPipe environment this seems to be the case.
