### PR TITLE
Fix decoy reversing for peptide fastas

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -46,7 +46,7 @@ func init() {
 		databaseCmd.Flags().BoolVarP(&m.Database.Rev, "reviewed", "", false, "use only reviwed sequences from Swiss-Prot")
 		databaseCmd.Flags().BoolVarP(&m.Database.Iso, "isoform", "", false, "add isoform sequences")
 		databaseCmd.Flags().BoolVarP(&m.Database.NoD, "nodecoys", "", false, "don't add decoys to the database")
-		databaseCmd.Flags().Int8VarP(&m.Database.DecoyMode, "decoymode", "", 0, "define the decoy generating mode, 0: revere sequence (default), 1:reverse and shift KR, 2:reverse and swap Kr")
+		databaseCmd.Flags().Int8VarP(&m.Database.DecoyMode, "decoymode", "", 0, "define the decoy generating mode, 0: revere sequence (default), 1:reverse and shift KR, 2:reverse and swap Kr, 3:reverse but keep KR in place (required for peptide-level databases)")
 		databaseCmd.Flags().BoolVarP(&m.Database.Verbose, "verbose", "", false, "debug the sequence classification for each FASTA record")
 	}
 

--- a/lib/dat/dat.go
+++ b/lib/dat/dat.go
@@ -369,6 +369,8 @@ func (d *Base) Create(temp, add, tag string, crap, noD, cTag bool, decoyMode int
 					revSeq = ReverseWithShiftKR(s)
 				case 2:
 					revSeq = ReverseAndSwapKR(s)
+				case 3:
+					revSeq = ReverseKeepKR(s)
 				default:
 					revSeq = reverseSeq(s)
 				}
@@ -667,5 +669,52 @@ func swapRK(c rune) rune {
 		return 'R'
 	default:
 		return c
+	}
+}
+
+// ReverseKeepKR reverses the residues within each K/R-delimited segment while
+// keeping every K and R at its original position (and keeping a leading M
+// unchanged). After in silico digestion with trypsin every decoy peptide still
+// ends in K or R, so the decoys keep the same cleavage-site layout, the same
+// missed-cleavage structure, and the same terminal-residue distribution as the
+// targets.
+//
+// This is the only mode that is safe for peptide-level databases, where each
+// FASTA entry is a single peptide and the search uses a no-cleavage enzyme, as
+// done in entrapment benchmarks. There, modes 0-2 move the C-terminal K/R away
+// from the C-terminus because no digestion step follows the reversal to restore
+// it, so every decoy becomes non-tryptic and loses target-decoy competition.
+func ReverseKeepKR(s string) string {
+
+	r := []rune(s)
+	n := len(r)
+	out := make([]rune, n)
+
+	var start int
+	if n > 0 && r[0] == 'M' {
+		out[0] = 'M'
+		start = 1
+	}
+
+	segStart := start
+	for i := start; i < n; i++ {
+		if r[i] == 'K' || r[i] == 'R' {
+			out[i] = r[i]
+			reverseInto(out[segStart:i], r[segStart:i])
+			segStart = i + 1
+		}
+	}
+
+	// trailing segment, when the sequence does not end in a cleavage residue
+	reverseInto(out[segStart:n], r[segStart:n])
+
+	return string(out)
+}
+
+// reverseInto writes src into dst in reverse order. len(dst) must equal len(src).
+func reverseInto(dst, src []rune) {
+	n := len(src)
+	for i := 0; i < n; i++ {
+		dst[n-1-i] = src[i]
 	}
 }

--- a/lib/dat/dat_test.go
+++ b/lib/dat/dat_test.go
@@ -3,6 +3,7 @@ package dat_test
 import (
 	"github.com/Nesvilab/philosopher/lib/fas"
 	"math"
+	"sort"
 	"testing"
 
 	. "github.com/Nesvilab/philosopher/lib/dat"
@@ -74,6 +75,62 @@ func TestBase_ProcessDB(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReverseKeepKR(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		// peptide-level database: one tryptic peptide per entry
+		{name: "Tryptic peptide ending in K", args: "AAAAALQAK", want: "AQLAAAAAK"},
+		{name: "Tryptic peptide ending in R", args: "LSAAEAQAVR", want: "VAQAEAASLR"},
+		{name: "Leading M is kept in place", args: "MPEPTIDEK", want: "MEDITPEPK"},
+		{name: "Odd length with leading M", args: "MASDEFGH", want: "MHGFEDSA"},
+		{name: "Internal K and R stay put", args: "SAKLGVR", want: "ASKVGLR"},
+		// protein-level database: digestion still yields K/R-terminated decoys
+		{name: "Protein with a non-tryptic tail", args: "MPEPTIDEKSAMPLERAAA", want: "MEDITPEPKELPMASRAAA"},
+		// edge cases
+		{name: "Empty sequence", args: "", want: ""},
+		{name: "No cleavage residue at all", args: "AAGGSS", want: "SSGGAA"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ReverseKeepKR(tt.args); got != tt.want {
+				t.Errorf("ReverseKeepKR(%q) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReverseKeepKR_PreservesTrypticCTerm(t *testing.T) {
+	// The defect this mode fixes: on a peptide-level database the existing modes
+	// move the C-terminal K/R to the front, so the decoys are no longer tryptic
+	// and are trivially separable from the targets.
+	peptides := []string{
+		"AAAAALQAK", "LSAAEAQAVR", "MPEPTIDEK", "HSEAAASK",
+		"EKETALTELR", "TGGRTEDELTR", "SPGDSPGGK", "EALEREAPGGK",
+	}
+	for _, p := range peptides {
+		d := ReverseKeepKR(p)
+		if len(d) != len(p) {
+			t.Errorf("ReverseKeepKR(%q) changed the length: got %d, want %d", p, len(d), len(p))
+		}
+		if d[len(d)-1] != p[len(p)-1] {
+			t.Errorf("ReverseKeepKR(%q) = %q, C-terminal residue changed from %c to %c",
+				p, d, p[len(p)-1], d[len(d)-1])
+		}
+		if sortedResidues(d) != sortedResidues(p) {
+			t.Errorf("ReverseKeepKR(%q) = %q, amino acid composition changed", p, d)
+		}
+	}
+}
+
+func sortedResidues(s string) string {
+	r := []byte(s)
+	sort.Slice(r, func(i, j int) bool { return r[i] < r[j] })
+	return string(r)
 }
 
 func TestBase_Deploy(t *testing.T) {


### PR DESCRIPTION
Fix decoy reversing for peptide fastas. Creates an additional mode (3) for creating decoys that fixes the position of the K/R.